### PR TITLE
Adding the remove command in lhsmtool_cmd

### DIFF
--- a/man/lhsmtool_cmd.1
+++ b/man/lhsmtool_cmd.1
@@ -86,8 +86,9 @@ as an archive, in which files are simply named after their FID in Lustre.
 .nf
 .ft C
 [commands]
-archive = dd if=/proc/self/{fd} of=/tmp/arch/{fid}
-restore = dd if=/tmp/arch/{fid} of=/proc/self/{fd}
+archive = dd if=/proc/self/fd/{fd} of=/tmp/arch/{fid}
+restore = dd if=/tmp/arch/{fid} of=/proc/self/fd/{fd}
+remove = rm /tmp/arch/{fid}
 .ft P
 .fi
 .UNINDENT

--- a/man/lhsmtool_cmd.rst
+++ b/man/lhsmtool_cmd.rst
@@ -65,8 +65,9 @@ as an archive, in which files are simply named after their FID in Lustre.
 ::
 
     [commands]
-    archive = dd if=/proc/self/{fd} of=/tmp/arch/{fid}
-    restore = dd if=/tmp/arch/{fid} of=/proc/self/{fd}
+    archive = dd if=/proc/self/fd/{fd} of=/tmp/arch/{fid}
+    restore = dd if=/tmp/arch/{fid} of=/proc/self/fd/{fd}
+    remove = rm /tmp/arch/{fid}
 
 OPTIONS
 =======

--- a/src/tools/lhsmtool_cmd.c
+++ b/src/tools/lhsmtool_cmd.c
@@ -555,7 +555,7 @@ static int ct_hsm_io_cmd(const enum hsm_copytool_action hsma, GMainLoop *loop,
 	cb_args->retcode	= -1;	/* for debugging */
 	cb_args->fd		= -1;
 
-	if (hsma == HSMA_ARCHIVE) {
+	if (hsma == HSMA_ARCHIVE || hsma == HSMA_REMOVE) {
 
 		rc = ct_begin(&cb_args->hcp, hai);
 		if (rc < 0) {
@@ -817,9 +817,9 @@ static gpointer subproc_mgr_main(gpointer data)
 		switch (hai->hai_action) {
 		case HSMA_ARCHIVE:
 		case HSMA_RESTORE:
+		case HSMA_REMOVE:
 			ct_hsm_io_cmd(hai->hai_action, loop, hai, hd->hd_flags);
 			break;
-		case HSMA_REMOVE:
 		case HSMA_CANCEL:
 			LOG_ERROR(ENOTSUP, "Operation not implemented");
 			break;


### PR DESCRIPTION
`lhsmtool_cmd` can now remove files from the HSM backend and will respond correctly to `lfs hsm_remove` command.